### PR TITLE
Clean Duke code and add Test Case for FindCommand

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -65,8 +65,7 @@ public class Duke {
 
     private String executeCommand(Command command) {
         command.setData(notebook, timetable, tagManager, storageManager);
-        String result = command.execute();
-        return result;
+        return command.execute();
     }
 
     /**

--- a/src/test/java/seedu/duke/command/FindCommandTest.java
+++ b/src/test/java/seedu/duke/command/FindCommandTest.java
@@ -1,10 +1,75 @@
 package seedu.duke.command;
 
+import org.junit.jupiter.api.BeforeEach;
+
+import seedu.duke.data.notebook.Note;
+import seedu.duke.data.notebook.Notebook;
+
 import org.junit.jupiter.api.Test;
+import seedu.duke.ui.InterfaceManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FindCommandTest {
 
+    Notebook notebook;
+
+    @BeforeEach
+    void setup() {
+        notebook = new Notebook();
+
+        Note defaultNote = new Note("Default", "default", false);
+        Note testNote1 = new Note("TestNote1", "default", false);
+        Note testNote2 = new Note("TestNote2", "default", false);
+
+        notebook.addNote(defaultNote);
+        notebook.addNote(testNote1);
+        notebook.addNote(testNote2);
+    }
+
     @Test
-    void execute() {
+    void execute_keywordTest_returnsTestNote1AndTestNote2() {
+        String keyword = "Test";
+
+        String expected = "Here are the matching notes in your list:"
+                + InterfaceManager.LS
+                + "1. TestNote1 "
+                + InterfaceManager.LS
+                + "2. TestNote2 "
+                + InterfaceManager.LS;
+        String result = getCommandExecutionString(notebook, keyword);
+
+        assertEquals(expected, result);
+
+    }
+
+    @Test
+    void execute_keywordDef_returnsDefault() {
+        String keyword = "def";
+
+        String expected = "Here are the matching notes in your list:"
+                + InterfaceManager.LS
+                + "1. Default "
+                + InterfaceManager.LS;
+        String result = getCommandExecutionString(notebook, keyword);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void execute_keywordNil_returnsNoSearchQuery() {
+        String keyword = "NIL";
+
+        String expected = "There are no matching notes. "
+                + "Please try another search query.";
+        String result = getCommandExecutionString(notebook, keyword);
+
+        assertEquals(expected, result);
+    }
+
+    private String getCommandExecutionString(Notebook notebook, String keyword) {
+        FindCommand findCommand = new FindCommand(keyword);
+        findCommand.setData(notebook, null, null, null);
+        return findCommand.execute();
     }
 }


### PR DESCRIPTION
Cleaned up Duke code
Test Cases for the following find-n scenarios
- Return 1 search query
- Return multiple search query
- Return no search query
